### PR TITLE
feat: add support for LaTeX-style bracket notation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@
  */
 
 import {mathFromMarkdown, mathToMarkdown} from 'mdast-util-math'
-import {math} from 'micromark-extension-math'
+import {math} from 'micromark-extension-math-extended'
 
 /** @type {Readonly<Options>} */
 const emptyOptions = {}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@types/mdast": "^4.0.0",
     "mdast-util-math": "^3.0.0",
-    "micromark-extension-math": "^3.0.0",
+    "micromark-extension-math-extended": "^3.0.0",
     "unified": "^11.0.0"
   },
   "description": "remark plugin to parse and stringify math",
@@ -70,7 +70,7 @@
       "logical-assignment-operators": "off"
     }
   },
-    "prettier": {
+  "prettier": {
     "bracketSpacing": false,
     "semi": false,
     "singleQuote": true,


### PR DESCRIPTION
This pull request updates the math parsing functionality by switching from the original `micromark-extension-math` package to the new `micromark-extension-math-extended` package. This change is reflected in both the code and the dependencies.

**Dependency update:**

* Replaced the `micromark-extension-math` dependency with `micromark-extension-math-extended` in `package.json` to use the extended math parsing capabilities.

**Code update:**

* Updated the import in `lib/index.js` to use `math` from `micromark-extension-math-extended` instead of `micromark-extension-math`.