### PR TITLE
feat: update imports and metadata for remark-math-extended

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 /**
  * @import {Root} from 'mdast'
- * @import {Options} from 'remark-math'
+ * @import {Options} from 'remark-math-extended'
  * @import {} from 'remark-parse'
  * @import {} from 'remark-stringify'
  * @import {Processor} from 'unified'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "author": "Junyoung Choi <fluke8259@gmail.com> (https://rokt33r.github.io)",
-  "bugs": "https://github.com/remarkjs/remark-math/issues",
+  "author": "Jerry Ho <jerrynh770@gmail.com> (https://angelrose.org)",
+  "bugs": "https://github.com/Jerrynh770/remark-math-extended/issues",
   "contributors": [
+    "Jerry Ho <jerrynh770@gmail.com> (https://angelrose.org)",
     "Junyoung Choi <fluke8259@gmail.com> (https://rokt33r.github.io)",
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
@@ -27,7 +28,7 @@
     "micromark-extension-math-extended": "^3.0.0",
     "unified": "^11.0.0"
   },
-  "description": "remark plugin to parse and stringify math",
+  "description": "Remark plugin that parses and stringifies math including \\(...\\) and \\[...\\]",
   "exports": "./index.js",
   "files": [
     "index.d.ts.map",
@@ -35,10 +36,6 @@
     "index.js",
     "lib/"
   ],
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/unified"
-  },
   "keywords": [
     "katex",
     "latex",
@@ -52,8 +49,8 @@
     "unified"
   ],
   "license": "MIT",
-  "name": "remark-math",
-  "repository": "https://github.com/remarkjs/remark-math/tree/main/packages/remark-math",
+  "name": "remark-math-extended",
+  "repository": "https://github.com/Jerrynh770/remark-math-extended",
   "scripts": {
     "build": "tsc --build --clean && tsc --build && type-coverage",
     "format": "remark --frail --output --quiet -- . && prettier --log-level warn --write -- . && xo --fix",
@@ -63,7 +60,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "xo": {
     "prettier": true,
     "rules": {

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ test('remarkMath', async function (t) {
     .use(rehypeStringify)
 
   await t.test('should expose the public api', async function () {
-    assert.deepEqual(Object.keys(await import('remark-math')).sort(), [
+    assert.deepEqual(Object.keys(await import('remark-math-extended')).sort(), [
       'default'
     ])
   })


### PR DESCRIPTION
This pull request updates the package to use the new `remark-math-extended` library, reflecting a change in project ownership and extending its math parsing capabilities. The changes update metadata, references, and descriptions to match the new package identity and functionality.

**Project renaming and ownership update:**

* Renamed the package from `remark-math` to `remark-math-extended` in `package.json`, updated the repository URL, author, and bug tracking information to reflect the new maintainer and repository. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R5) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L55-R53)
* Added the new maintainer to the contributors list in `package.json`.

**Functionality and API changes:**

* Changed the import in `lib/index.js` from `remark-math` to `remark-math-extended`, updating the `Options` type reference.
* Updated the package description in `package.json` to clarify extended math parsing support for `\(...\)` and `\[...\]`.
* Updated the test suite to import and check the public API of `remark-math-extended` instead of `remark-math`.

**Versioning:**

* Bumped the package version from `6.0.0` to `6.1.0` in `package.json` to indicate a new release with these changes.